### PR TITLE
fix: Wrap connection errors in Redis

### DIFF
--- a/src/backingServices/RedisPubSubClient.spec.ts
+++ b/src/backingServices/RedisPubSubClient.spec.ts
@@ -158,10 +158,7 @@ describe('RedisPubSubClient', () => {
       mockRedisClient.connect.mockRejectedValueOnce(error);
       mockCreateClient.mockReturnValueOnce(mockRedisClient);
 
-      const errorWrapped = await getPromiseRejection(
-        client.makePublisher(),
-        RedisPubSubError,
-      );
+      const errorWrapped = await getPromiseRejection(client.makePublisher(), RedisPubSubError);
 
       expect(errorWrapped.message).toStartWith('Failed to connect to Redis');
       expect(errorWrapped.cause()).toBe(error);

--- a/src/backingServices/RedisPubSubClient.spec.ts
+++ b/src/backingServices/RedisPubSubClient.spec.ts
@@ -48,6 +48,22 @@ describe('RedisPubSubClient', () => {
       expect(redisClient.connect).toHaveBeenCalledBefore(redisClient.subscribe);
     });
 
+    test('Should wrap connection errors', async () => {
+      const client = RedisPubSubClient.init();
+      const mockRedisClient = new MockRedisClient();
+      const error = new Error('the error');
+      mockRedisClient.connect.mockRejectedValueOnce(error);
+      mockCreateClient.mockReturnValueOnce(mockRedisClient);
+
+      const errorWrapped = await getPromiseRejection(
+        collect(client.subscribe(channel)),
+        RedisPubSubError,
+      );
+
+      expect(errorWrapped.message).toStartWith('Failed to connect to Redis');
+      expect(errorWrapped.cause()).toBe(error);
+    });
+
     test('Should subscribe to specified channel', async () => {
       const client = RedisPubSubClient.init();
       emitMessagesAsync(['message']);
@@ -133,6 +149,22 @@ describe('RedisPubSubClient', () => {
 
       const redisClient = getMockedRedisClient();
       expect(redisClient.connect).toHaveBeenCalledOnce();
+    });
+
+    test('Should wrap connection errors', async () => {
+      const client = RedisPubSubClient.init();
+      const mockRedisClient = new MockRedisClient();
+      const error = new Error('the error');
+      mockRedisClient.connect.mockRejectedValueOnce(error);
+      mockCreateClient.mockReturnValueOnce(mockRedisClient);
+
+      const errorWrapped = await getPromiseRejection(
+        client.makePublisher(),
+        RedisPubSubError,
+      );
+
+      expect(errorWrapped.message).toStartWith('Failed to connect to Redis');
+      expect(errorWrapped.cause()).toBe(error);
     });
 
     describe('Publish', () => {

--- a/src/backingServices/RedisPubSubClient.ts
+++ b/src/backingServices/RedisPubSubClient.ts
@@ -77,7 +77,11 @@ export class RedisPubSubClient {
 
   private async connect(): Promise<RedisClientType> {
     const redisClient = createClient({ url: this.redisUrl });
-    await redisClient.connect();
+    try {
+      await redisClient.connect();
+    } catch (err) {
+      throw new RedisPubSubError(err as Error, 'Failed to connect to Redis');
+    }
     return redisClient as RedisClientType;
   }
 }


### PR DESCRIPTION
So we can know they're related to Redis, since the Redis lib isn't very helpful.
